### PR TITLE
Add page content field for page level

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Supported datasource options:
 |------|-------------|---------|
 | `source` | Specifies the source of the table: `parquet`, or `file` (any other format) | Automatically inferred from the path
 | `level` | Shows level of metadata for the `source`. Values are `file` (file metadata), `rowgroup` (Parquet row group metadata), `column` (Parquet column chunk metadata), `page` (Parquet page metadata). Note that not all of the sources support all levels | `file`
-| `maxparts` | Defines the number of partitions to use when reading data. For example, if you have hundreds of thousands of files, you can use this option to read all of the data in 2000 partitions instead | `min(200, files.length)`
-| `buffersize` | Sets buffer size in bytes for reading Parquet page level data. This reduces the amount of remote calls to DBFS, S3, WASB, ABFS, etc. It is recommended to use a large value, e.g. 64 MB or 128 MB | `128 MB`, typical row group size
+| `maxParts` | Defines the number of partitions to use when reading data. For example, if you have hundreds of thousands of files, you can use this option to read all of the data in 2000 partitions instead | `min(200, files.length)`
+| `bufferSize` | Sets buffer size in bytes for reading Parquet page level data. This reduces the amount of remote calls to DBFS, S3, WASB, ABFS, etc. It is recommended to use a large value, e.g. 64 MB or 128 MB | `128 MB`, typical row group size
+| `pageContent` | Enables page content for the `page` level, available values are `true` or `false`. It is recommended to only enable it when inspecting a particular set of pages | `false`
 
 DataFrame schema for each level is in
 [MetadataLevel.scala](./src/main/scala/com/github/sadikovi/metadata/MetadataLevel.scala).

--- a/src/main/scala/com/github/sadikovi/metadata/MetadataFileFormat.scala
+++ b/src/main/scala/com/github/sadikovi/metadata/MetadataFileFormat.scala
@@ -136,7 +136,8 @@ class ParquetMetadataFileFormat(
     fileIndex: FileIndex,
     level: MetadataLevel,
     maxPartitions: Int,
-    bufferSize: Int)
+    bufferSize: Int,
+    pageContentEnabled: Boolean)
   extends MetadataFileFormat(spark, fileIndex, level, maxPartitions) {
 
   require(
@@ -249,6 +250,14 @@ class ParquetMetadataFileFormat(
                 ))
               }
 
+              val pageContent: Option[Array[Byte]] = if (pageContentEnabled) {
+                val tmp = new Array[Byte](page.compressedPageSize)
+                in.readFully(tmp, 0, tmp.length)
+                Some(tmp)
+              } else {
+                None
+              }
+
               val values = Array(
                 cols(colIndex).rowGroupId,
                 cols(colIndex).id,
@@ -264,6 +273,7 @@ class ParquetMetadataFileFormat(
                 page.definitionEncoding,
                 page.repetitionEncoding,
                 statistics,
+                pageContent,
                 file.path
               )
 

--- a/src/main/scala/com/github/sadikovi/metadata/MetadataLevel.scala
+++ b/src/main/scala/com/github/sadikovi/metadata/MetadataLevel.scala
@@ -87,6 +87,7 @@ object ParquetPageLevel extends MetadataLevel {
       StructField("min_value_length", IntegerType) ::
       StructField("max_value_length", IntegerType) ::
       Nil)) ::
+    StructField("page_content", ArrayType(ByteType)) ::
     StructField("filepath", StringType) ::
     Nil)
 }

--- a/src/main/scala/com/github/sadikovi/metadata/RemoteInputStream.scala
+++ b/src/main/scala/com/github/sadikovi/metadata/RemoteInputStream.scala
@@ -1,6 +1,6 @@
 package com.github.sadikovi.metadata
 
-import java.io.{IOException, InputStream}
+import java.io.{EOFException, IOException, InputStream}
 import org.apache.hadoop.fs.Seekable
 
 /**
@@ -46,6 +46,20 @@ class RemoteInputStream(
     val bytesRead = copyFromBuf(arr, off, len)
     pos += bytesRead
     bytesRead
+  }
+
+  /** Naive implementation of readFully method */
+  def readFully(arr: Array[Byte], off: Int, len: Int): Unit = {
+    var bytesRead = len
+    var currOffset = off
+    while (bytesRead > 0) {
+      val bytes = read(arr, currOffset, bytesRead)
+      if (bytes < 0) {
+        throw new EOFException(s"Failed to read bytes at off $off and len $len: $bytes")
+      }
+      bytesRead -= bytes
+      currOffset += bytes
+    }
   }
 
   override def skip(bytes: Long): Long = {


### PR DESCRIPTION
This PR adds an option to enable page content when viewing individual pages. When you specify `pageContent = true` in DataFrame options, page level metadata will populate `page_content` column. 

Make sure to only use it when inspecting individual pages otherwise it might affect performance.